### PR TITLE
fix: add missing modal class

### DIFF
--- a/src/components/ImageModal.astro
+++ b/src/components/ImageModal.astro
@@ -8,7 +8,7 @@ const { id } = Astro.props;
 
 <div
   id={id}
-  class="fixed inset-0 bg-black/50 z-50 hidden items-center justify-center p-4"
+  class="modal fixed inset-0 bg-black/50 z-50 hidden items-center justify-center p-4"
   onclick="this.classList.add('hidden'); this.classList.remove('flex');"
 >
   <div class="max-w-4xl w-full bg-white rounded-lg overflow-hidden shadow-xl">


### PR DESCRIPTION
## Summary
- ensure modal close button finds its container by adding missing `modal` class

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689375f13530832d93305f978394db38