### PR TITLE
Fix February report date typos

### DIFF
--- a/src/data/reports.ts
+++ b/src/data/reports.ts
@@ -131,7 +131,7 @@ export const reports = [
     ]
   },
   {
-    date: 'February 23th, 2025',
+    date: 'February 23rd, 2025',
     author: 'Morax Cheng',
     achievements: [
       'Implemented responsive design for team member profiles page',
@@ -170,7 +170,7 @@ export const reports = [
     ]
   },
   {
-    date: 'February 2th, 2025',
+    date: 'February 2nd, 2025',
     author: 'Morax Cheng',
     achievements: [
       'Set up project documentation structure',


### PR DESCRIPTION
## Summary
- correct February report dates: `February 23rd, 2025` and `February 2nd, 2025`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689377495c34832dbc915c13ea96d712